### PR TITLE
QEA-362: use request.get_data() to get POST data

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -692,15 +692,12 @@ def file(p):
             r.headers = {'Content-Type': 'application/json'}
             return r
 
-        # add options:
-        ## grep for an expression in the file content
-
         return return_files(dir_path=p, name=filename, ctime=ctime, limit=limit)
 
     elif request.method == 'POST':
         # A file of name 'filename' will be created in 'p' directory
         # If the file already exists, create_file() will fail
-        data = request.data
+        data = request.get_data()
         ctype = request.headers.get('Content-Type', None)
 
         res = create_file(path=p, content=data, filename=filename, ctype=ctype)

--- a/httpbin/helpers.py
+++ b/httpbin/helpers.py
@@ -559,7 +559,12 @@ def _get_file_details(fpath):
 
     parts = fpath.rsplit('/', 1)
     filename = parts[len(parts)-1]
-    name, ext = filename.rsplit('.',1)
+    name_split = filename.rsplit('.',1)
+
+    name = name_split[0]
+    ext = ""
+    if len(name_split) == 2:
+        ext = name_split[1]
 
     mimetype = 'application/octet-stream'
     if ext in ["txt", "text"]:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = open(
 
 setup(
     name="httpbin-sp",
-    version="0.5.0",
+    version="0.5.1",
     description="HTTP Request and Response Service",
     long_description=long_description,
 


### PR DESCRIPTION
The current implementation is broken as it uses `request.data` to fetch POST data.  It is deprecated and may not always return the data (see flask documentation for details).

Use `request.get_data()` instead.

Also fixes `_get_file_details()` helper method that breaks when the filename does not have an extension
